### PR TITLE
Add JACK timebase support to example applications.

### DIFF
--- a/examples/linkaudio/AudioPlatform_Jack.hpp
+++ b/examples/linkaudio/AudioPlatform_Jack.hpp
@@ -40,6 +40,16 @@ private:
   static int audioCallback(jack_nframes_t nframes, void* pvUserData);
   int audioCallback(jack_nframes_t nframes);
 
+  static void timebaseCallback(jack_transport_state_t state,
+    jack_nframes_t nframes,
+    jack_position_t* position,
+    int new_pos,
+    void* pvUserData);
+  void timebaseCallback(jack_transport_state_t state,
+    jack_nframes_t nframes,
+    jack_position_t* position,
+    int new_pos);
+
   void initialize();
   void uninitialize();
   void start();


### PR DESCRIPTION
Add JACK Timebase master support to example applications, updating extended BBT (bar.beat.tick) position and BPM (tempo) information, as read from Link and proposed as an one-way bridge to JACK Transport interface.