### PR TITLE
Make the Link clock in STL platforms have a common reference

### DIFF
--- a/include/ableton/platforms/stl/Clock.hpp
+++ b/include/ableton/platforms/stl/Clock.hpp
@@ -32,18 +32,12 @@ struct Clock
 {
   using Ticks = std::uint64_t;
 
-  Clock()
-  {
-    mStartTime = std::chrono::high_resolution_clock::now();
-  }
-
   std::chrono::microseconds micros() const
   {
     using namespace std::chrono;
-    return duration_cast<microseconds>(high_resolution_clock::now() - mStartTime);
+    auto nowInMicros = time_point_cast<microseconds>(high_resolution_clock::now());
+    return nowInMicros.time_since_epoch();
   }
-
-  std::chrono::high_resolution_clock::time_point mStartTime;
 };
 
 } // namespace stl


### PR DESCRIPTION
In OSC and Windows, the platform Clock used by Link is based on a common
reference, so that its value could be shared between applications.

In the STL Link clock implementation, the clock has a reference that
is dependent on the application start, so the Clock value only has
meaning to that application.

This is good in most cases, when the application using the clock data is
the same as the one using the timeline, since the Clock will be the
same. BUT if the application getting the clock data and the application
using such data are not the same, then they can't share it, since the
one using the data does not have the same reference as the other one.

This use model can be useful for example, if we want to have a "proxy"
Link app, that relays the Link information to another app. This would
work out of the box on Windows and OSX, but not on platforms using the
STL clock abstraction. We are planning to use such a model in Sonic PI,
in which there will be a small C++ proxy communicating with Link and
relaying the information to the Sonic PI ruby server (and back in
the other direction as well).

This patch changes the value returned by the Link Clock, so that it has
a common reference, in this case the standard epoch as returned by the
same STL library.

This way the behaviour on all platforms regarding clock semantics is the
same.