### PR TITLE
Use CLOCK_MONOTONIC_RAW by default on Linux

### DIFF
--- a/include/ableton/platforms/Config.hpp
+++ b/include/ableton/platforms/Config.hpp
@@ -54,7 +54,7 @@ using IoContext =
   platforms::asio::Context<platforms::posix::ScanIpIfAddrs, util::NullLog>;
 
 #elif defined(LINK_PLATFORM_LINUX)
-using Clock = platforms::linux::ClockMonotonic;
+using Clock = platforms::linux::ClockMonotonicRaw;
 using IoContext =
   platforms::asio::Context<platforms::posix::ScanIpIfAddrs, util::NullLog>;
 #endif


### PR DESCRIPTION
Hi,

As Link requires the clock to not jump and be strictly monotonic, then CLOCK_MONOTONIC_RAW is the most suitable clock.

From man 2 clock_gettime:
>        CLOCK_MONOTONIC
>               Clock  that  cannot  be set and represents monotonic time since
>               some unspecified starting point.  This clock is not affected by
>               discontinuous  jumps  in  the  system time (e.g., if the system
>               administrator manually changes the clock), but is  affected  by
>               the incremental adjustments performed by adjtime(3) and NTP.
> 
>        CLOCK_MONOTONIC_RAW (since Linux 2.6.28; Linux-specific)
>               Similar to CLOCK_MONOTONIC, but provides access to a raw  hard‐
>               ware-based  time  that is not subject to NTP adjustments or the
>               incremental adjustments performed by adjtime(3).

Thank you,
Alex.