### PR TITLE
Add links to Linux Audio Conf paper and video

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,10 +173,17 @@ example apps.
 
 ## Technical summary
 
-A technical overview of the Link protocol is available in the paper ["Ableton Link - A technology to synchronize music software"](https://depositonce.tu-berlin.de/bitstream/11303/7886/4/LAC2018_proceedings.pdf#page=51) published in the [Proceedings of the Linux Audio Conference 2018](https://lac.linuxaudio.org/2018/). A video presentation is available [here](https://media.ccc.de/v/lac2018-42-ableton_link_a_technology_to_synchronize_music_software)
+A technical overview of the Link protocol is available in the paper ["Ableton Link - A 
+technology to synchronize music software"](linux-audio-conf-proceedings) published in the
+[Proceedings of the Linux Audio Conference 2018](linux-audio-conf). A video presentation 
+is available [here](linux-audio-conf-presentation)
 
 [asio]: https://www.steinberg.net/en/company/developers.html
 [catch]: https://github.com/philsquared/Catch
 [cmake]: https://www.cmake.org
 [license]: LICENSE.md
+[linux-audio-conf]: https://lac.linuxaudio.org/2018/
+[linux-audio-conf-presentation]: https://media.ccc.de/v/lac2018-42-ableton_link_a_technology_to_synchronize_music_software
+[linux-audio-conf-proceedings]: https://depositonce.tu-berlin.de/bitstream/11303/7886/4/LAC2018_proceedings.pdf#page=51
 [qt]: https://www.qt.io
+

--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ to system time values before passing them to Link methods. Examples of this late
 compensation can be found in the [platform](examples/linkaudio) implementations of the
 example apps.
 
+## Technical summary
+
+A technical overview of the Link protocol is available in the paper ["Ableton Link - A technology to synchronize music software"](https://depositonce.tu-berlin.de/bitstream/11303/7886/4/LAC2018_proceedings.pdf#page=51) published in the [Proceedings of the Linux Audio Conference 2018](https://lac.linuxaudio.org/2018/). A video presentation is available [here](https://media.ccc.de/v/lac2018-42-ableton_link_a_technology_to_synchronize_music_software)
+
 [asio]: https://www.steinberg.net/en/company/developers.html
 [catch]: https://github.com/philsquared/Catch
 [cmake]: https://www.cmake.org


### PR DESCRIPTION
These contain documentation that is not available elsewhere which may be useful for developers who are currently working on integrations.