### PR TITLE
ESP32 port for esp-idf release/v4.0

### DIFF
--- a/include/ableton/discovery/NetworkByteStreamSerializable.hpp
+++ b/include/ableton/discovery/NetworkByteStreamSerializable.hpp
@@ -24,6 +24,8 @@
 #include <ableton/platforms/darwin/Darwin.hpp>
 #elif defined(LINK_PLATFORM_LINUX)
 #include <ableton/platforms/linux/Linux.hpp>
+#elif defined(ESP_PLATFORM)
+#include <ableton/platforms/esp32/ESP32.hpp>
 #endif
 
 #include <chrono>

--- a/include/ableton/link/NodeId.hpp
+++ b/include/ableton/link/NodeId.hpp
@@ -45,15 +45,20 @@ struct NodeId : NodeIdArray
   static NodeId random()
   {
     using namespace std;
+    NodeId nodeId;
 
+#ifdef ESP_PLATFORM
+    generate(nodeId.begin(), nodeId.end(),
+      [&] { return static_cast<uint8_t>((esp_random() % 93) + 33); });
+#else
     random_device rd;
     mt19937 gen(rd());
     // uint8_t not standardized for this type - use unsigned
     uniform_int_distribution<unsigned> dist(33, 126); // printable ascii chars
-
-    NodeId nodeId;
     generate(
       nodeId.begin(), nodeId.end(), [&] { return static_cast<uint8_t>(dist(gen)); });
+#endif
+
     return nodeId;
   }
 

--- a/include/ableton/platforms/Config.hpp
+++ b/include/ableton/platforms/Config.hpp
@@ -34,6 +34,10 @@
 #include <ableton/platforms/asio/Context.hpp>
 #include <ableton/platforms/linux/Clock.hpp>
 #include <ableton/platforms/posix/ScanIpIfAddrs.hpp>
+#elif defined(ESP_PLATFORM)
+#include <ableton/platforms/asio/Context.hpp>
+#include <ableton/platforms/esp32/Clock.hpp>
+#include <ableton/platforms/esp32/ScanIpIfAddrs.hpp>
 #endif
 
 namespace ableton
@@ -57,6 +61,10 @@ using IoContext =
 using Clock = platforms::linux::ClockMonotonic;
 using IoContext =
   platforms::asio::Context<platforms::posix::ScanIpIfAddrs, util::NullLog>;
+#elif defined(ESP_PLATFORM)
+using Clock = platforms::esp32::Clock;
+using IoContext =
+  platforms::asio::Context<platforms::esp32::ScanIpIfAddrs, util::NullLog>;
 #endif
 
 using Controller =

--- a/include/ableton/platforms/asio/AsioWrapper.hpp
+++ b/include/ableton/platforms/asio/AsioWrapper.hpp
@@ -26,11 +26,13 @@
  * by Link.
  */
 
+#if !defined(ESP_PLATFORM)
 #pragma push_macro("ASIO_STANDALONE")
 #define ASIO_STANDALONE 1
 
 #pragma push_macro("ASIO_NO_TYPEID")
 #define ASIO_NO_TYPEID 1
+#endif
 
 #if defined(LINK_PLATFORM_WINDOWS)
 #pragma push_macro("INCL_EXTRA_HTON_FUNCTIONS")

--- a/include/ableton/platforms/esp32/Clock.hpp
+++ b/include/ableton/platforms/esp32/Clock.hpp
@@ -1,0 +1,36 @@
+/* Copyright 2019, Mathias Bredholt, Torso Electronics, Copenhagen. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "esp_timer.h"
+
+namespace ableton
+{
+namespace platforms
+{
+namespace esp32
+{
+struct Clock
+{
+  std::chrono::microseconds micros() const
+  {
+    return static_cast<std::chrono::microseconds>(esp_timer_get_time());
+  }
+};
+} // namespace esp32
+} // namespace platforms
+} // namespace ableton

--- a/include/ableton/platforms/esp32/ESP32.hpp
+++ b/include/ableton/platforms/esp32/ESP32.hpp
@@ -1,0 +1,35 @@
+/* Copyright 2019, Mathias Bredholt, Torso Electronics, Copenhagen. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+inline uint64_t __bswap64(uint64_t _x)
+{
+  return ((uint64_t)((_x >> 56) | ((_x >> 40) & 0xff00) | ((_x >> 24) & 0xff0000)
+                     | ((_x >> 8) & 0xff000000) | ((_x << 8) & ((uint64_t)0xff << 32))
+                     | ((_x << 24) & ((uint64_t)0xff << 40))
+                     | ((_x << 40) & ((uint64_t)0xff << 48)) | ((_x << 56))));
+}
+
+#ifndef ntohll
+#define ntohll(x) __bswap64(x)
+#endif
+
+#ifndef htonll
+#define htonll(x) __bswap64(x)
+#endif

--- a/include/ableton/platforms/esp32/ScanIpIfAddrs.hpp
+++ b/include/ableton/platforms/esp32/ScanIpIfAddrs.hpp
@@ -1,0 +1,48 @@
+/* Copyright 2019, Mathias Bredholt, Torso Electronics, Copenhagen. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <ableton/platforms/asio/AsioWrapper.hpp>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <vector>
+
+#include "tcpip_adapter.h"
+
+namespace ableton
+{
+namespace platforms
+{
+namespace esp32
+{
+
+// ESP32 implementation of ip interface address scanner
+struct ScanIpIfAddrs
+{
+  std::vector<::asio::ip::address> operator()()
+  {
+    std::vector<::asio::ip::address> addrs;
+    tcpip_adapter_ip_info_t ip_info;
+    tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_STA, &ip_info);
+    addrs.emplace_back(::asio::ip::address_v4(ntohl(ip_info.ip.addr)));
+    return addrs;
+  }
+};
+
+} // namespace esp32
+} // namespace platforms
+} // namespace ableton


### PR DESCRIPTION
This is a port of the Link platform for ESP32. This allows for using Link through the WiFi capabilities of the ESP32 module. It was made possible by the work of the contributors of porting [asio](https://github.com/espressif/asio) to ESP32. The port is at a reasonably stable state and has been tested as part of the development of the algorithmic sequencer "T-1" by [Torso Electronics](https://www.torsoelectronics.com/).

It's tested with esp-idf release/v4.0 with the following changes in sdkconfig (idf.py menuconfig)
```
CONFIG_PTHREAD_TASK_STACK_SIZE_DEFAULT=4608
ONFIG_LWIP_MAX_SOCKETS=16
```
It requires an implementation of the following functions that are missing from esp-idf. We have used the following naive implementations. 
```
unsigned int if_nametoindex(const char *ifname) {
    return 0;
}

char *if_indextoname(unsigned int ifindex, char *ifname) {
    return nullptr;
}
```
Finally, the translation unit that includes the Link header, has to be compiled with the `-fexceptions` flag.

I'm working on a minimal example project of using this with the esp-idf. 

We hope that this will be useful for anyone wanting to build new hardware sequencers, synthesizers and eurorack modules with Link synchronization! On the long run it could be interesting to make this into an Arduino library to open the Link platform for DIY developers.