### PR TITLE
Esp32 update for esp-idf v4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ matrix:
         apt:
           sources: ['llvm-toolchain-trusty-5.0', 'ubuntu-toolchain-r-test']
           packages: ['wget', 'flex', 'bison', 'gperf', 'python-pip', 'ninja-build', 'ccache']
-      env: IDF_RELEASE=v4.0-rc IDF_PATH=${HOME}/esp-idf-${IDF_RELEASE} COMPILER=clang
+      env: IDF_RELEASE=v4.1 IDF_PATH=${HOME}/esp-idf-${IDF_RELEASE} COMPILER=clang
 
     # Code formatting verification
     - os: linux

--- a/include/ableton/platforms/esp32/ScanIpIfAddrs.hpp
+++ b/include/ableton/platforms/esp32/ScanIpIfAddrs.hpp
@@ -20,7 +20,7 @@
 #include <ableton/platforms/asio/AsioWrapper.hpp>
 #include <arpa/inet.h>
 #include <net/if.h>
-#include <tcpip_adapter.h>
+#include <esp_netif.h>
 #include <vector>
 
 namespace ableton
@@ -36,11 +36,18 @@ struct ScanIpIfAddrs
   std::vector<::asio::ip::address> operator()()
   {
     std::vector<::asio::ip::address> addrs;
-    tcpip_adapter_ip_info_t ip_info;
-    if (ESP_OK == tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_STA, &ip_info)
-        && tcpip_adapter_is_netif_up(TCPIP_ADAPTER_IF_STA) && ip_info.ip.addr)
+    // Get first network interface
+    esp_netif_t* esp_netif = esp_netif_next(NULL);
+    while (esp_netif)
     {
-      addrs.emplace_back(::asio::ip::address_v4(ntohl(ip_info.ip.addr)));
+      // Check if interface is active
+      if (esp_netif_is_netif_up(esp_netif)) {
+        esp_netif_ip_info_t ip_info;
+        esp_netif_get_ip_info(esp_netif, &ip_info);
+        addrs.emplace_back(::asio::ip::address_v4(ntohl(ip_info.ip.addr)));
+      }
+      // Get next network interface
+      esp_netif = esp_netif_next(esp_netif);
     }
     return addrs;
   }


### PR DESCRIPTION
Just an update for the Esp32 port, using the new esp_netif API. This should allow to use Link with Esp32 with both STA, SoftAP, and Ethernet.