### PR TITLE
Add "/wd4503" only if on MSVC compiler

### DIFF
--- a/AbletonLinkConfig.cmake
+++ b/AbletonLinkConfig.cmake
@@ -31,10 +31,12 @@ elseif(WIN32)
     INTERFACE_COMPILE_DEFINITIONS
     LINK_PLATFORM_WINDOWS=1
   )
-  set_property(TARGET Ableton::Link APPEND PROPERTY
-    INTERFACE_COMPILE_OPTIONS
-    "/wd4503" # 'Identifier': decorated name length exceeded, name was truncated
-  )
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    set_property(TARGET Ableton::Link APPEND PROPERTY
+      INTERFACE_COMPILE_OPTIONS
+      "/wd4503" # 'Identifier': decorated name length exceeded, name was truncated
+    )
+  endif()
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set_property(TARGET Ableton::Link APPEND PROPERTY
     INTERFACE_COMPILE_DEFINITIONS


### PR DESCRIPTION
This issue is also related to MinGW (#69) but not related to `htonll` and `ntohll`, so I guess it belong to another PR.

https://github.com/Ableton/link/blob/master/AbletonLinkConfig.cmake#L36

```cmake
set_property(TARGET Ableton::Link APPEND PROPERTY
  INTERFACE_COMPILE_OPTIONS
  "/wd4503" # 'Identifier': decorated name length exceeded, name was truncated
)
```

`/wd4503` is recognized as a directory by GCC and fails as its only recognized by MSVC compiler :

```
error: /wd4503: No such file or directory
```