### PR TITLE
Make Link become a template which takes a Clock parameter

### DIFF
--- a/include/ableton/Link.hpp
+++ b/include/ableton/Link.hpp
@@ -65,20 +65,20 @@ namespace ableton
  *  concurrently is not advised and will potentially lead to unexpected
  *  behavior.
  */
-class Link
+template <typename Clock>
+class BasicLink
 {
 public:
-  using Clock = link::platform::Clock;
   class SessionState;
 
   /*! @brief Construct with an initial tempo. */
-  Link(double bpm);
+  BasicLink(double bpm);
 
   /*! @brief Link instances cannot be copied or moved */
-  Link(const Link&) = delete;
-  Link& operator=(const Link&) = delete;
-  Link(Link&&) = delete;
-  Link& operator=(Link&&) = delete;
+  BasicLink(const BasicLink<Clock>&) = delete;
+  BasicLink& operator=(const BasicLink<Clock>&) = delete;
+  BasicLink(BasicLink<Clock>&&) = delete;
+  BasicLink& operator=(BasicLink<Clock>&&) = delete;
 
   /*! @brief Is Link currently enabled?
    *  Thread-safe: yes
@@ -359,19 +359,36 @@ public:
       bool isPlaying, std::chrono::microseconds time, double beat, double quantum);
 
   private:
-    friend Link;
+    friend BasicLink<Clock>;
     link::ApiState mOriginalState;
     link::ApiState mState;
     bool mbRespectQuantum;
   };
 
 private:
+  using Controller = ableton::link::Controller<
+    link::PeerCountCallback,
+    link::TempoCallback,
+    link::StartStopStateCallback,
+    Clock,
+    link::platform::Random,
+    link::platform::IoContext>;
+
   std::mutex mCallbackMutex;
-  link::PeerCountCallback mPeerCountCallback;
-  link::TempoCallback mTempoCallback;
-  link::StartStopStateCallback mStartStopCallback;
+  link::PeerCountCallback mPeerCountCallback = [](std::size_t) {};
+  link::TempoCallback mTempoCallback = [](link::Tempo) {};
+  link::StartStopStateCallback mStartStopCallback = [](bool) {};
   Clock mClock;
-  link::platform::Controller mController;
+  Controller mController;
+};
+
+class Link : public BasicLink<link::platform::Clock>
+{
+public:
+  Link(double bpm)
+    : BasicLink(bpm)
+  {
+  }
 };
 
 } // namespace ableton

--- a/include/ableton/platforms/Config.hpp
+++ b/include/ableton/platforms/Config.hpp
@@ -76,9 +76,6 @@ using IoContext =
 using Random = platforms::esp32::Random;
 #endif
 
-using Controller =
-  Controller<PeerCountCallback, TempoCallback, StartStopStateCallback, Clock, Random, IoContext>;
-
 } // namespace platform
 } // namespace link
 } // namespace ableton


### PR DESCRIPTION
This allows to use a custom clock, for example the one coming from the audio interface or simply the realtime clock.

I've made a similar request in the past and it was discarded, but I'd like you to consider it again.
In Bitwig we don't use the MONOTONIC_RAW clock, we use the realtime one, because this is the same clock being used by alsa, by pthread_*_timedwait() functions, by semaphore wait functions, etc...

You can't use the monotonic clock with every apis, which makes the realtime one the only clock that work across all the system interfaces.

I do not mean that the realtime clock should be the default, but it should be an option to use it.

Thank youl,
Alex