### PR TITLE
Simplify the source code in order to compile with clang-cl.exe 10.0

### DIFF
--- a/include/ableton/link/Beats.hpp
+++ b/include/ableton/link/Beats.hpp
@@ -22,60 +22,79 @@
 #include <ableton/discovery/NetworkByteStreamSerializable.hpp>
 #include <cmath>
 #include <cstdint>
-#include <tuple>
 
 namespace ableton
 {
 namespace link
 {
 
-struct Beats : std::tuple<std::int64_t>
+struct Beats
 {
   Beats() = default;
 
   explicit Beats(const double beats)
-    : std::tuple<std::int64_t>(llround(beats * 1e6))
+    : mValue(std::llround(beats * 1e6))
   {
   }
 
   explicit Beats(const std::int64_t microBeats)
-    : std::tuple<std::int64_t>(microBeats)
+    : mValue(microBeats)
   {
   }
 
   double floating() const
   {
-    return microBeats() / 1e6;
+    return mValue / 1e6;
   }
 
   std::int64_t microBeats() const
   {
-    return std::get<0>(*this);
+    return mValue;
   }
 
   Beats operator-() const
   {
-    return Beats{-microBeats()};
+    return Beats{-mValue};
   }
 
   friend Beats abs(const Beats b)
   {
-    return Beats{std::abs(b.microBeats())};
+    return Beats{std::abs(b.mValue)};
   }
 
   friend Beats operator+(const Beats lhs, const Beats rhs)
   {
-    return Beats{lhs.microBeats() + rhs.microBeats()};
+    return Beats{lhs.mValue + rhs.mValue};
   }
 
   friend Beats operator-(const Beats lhs, const Beats rhs)
   {
-    return Beats{lhs.microBeats() - rhs.microBeats()};
+    return Beats{lhs.mValue - rhs.mValue};
   }
 
   friend Beats operator%(const Beats lhs, const Beats rhs)
   {
-    return rhs == Beats{0.} ? Beats{0.} : Beats{lhs.microBeats() % rhs.microBeats()};
+    return Beats{rhs.mValue == 0 ? 0 : (lhs.mValue % rhs.mValue)};
+  }
+
+  friend bool operator<(const Beats lhs, const Beats rhs)
+  {
+    return lhs.mValue < rhs.mValue;
+  }
+
+  friend bool operator>(const Beats lhs, const Beats rhs)
+  {
+    return lhs.mValue > rhs.mValue;
+  }
+
+  friend bool operator==(const Beats lhs, const Beats rhs)
+  {
+    return lhs.mValue == rhs.mValue;
+  }
+
+  friend bool operator!=(const Beats lhs, const Beats rhs)
+  {
+    return lhs.mValue != rhs.mValue;
   }
 
   // Model the NetworkByteStreamSerializable concept
@@ -97,6 +116,9 @@ struct Beats : std::tuple<std::int64_t>
       std::move(begin), std::move(end));
     return std::make_pair(Beats{result.first}, std::move(result.second));
   }
+
+private:
+    std::int64_t mValue = 0;
 };
 
 } // namespace link

--- a/include/ableton/link/Tempo.hpp
+++ b/include/ableton/link/Tempo.hpp
@@ -27,29 +27,29 @@ namespace ableton
 namespace link
 {
 
-struct Tempo : std::tuple<double>
+struct Tempo
 {
   Tempo() = default;
 
   // Beats per minute
   explicit Tempo(const double bpm)
-    : std::tuple<double>(bpm)
+    : mValue(bpm)
   {
   }
 
   Tempo(const std::chrono::microseconds microsPerBeat)
-    : std::tuple<double>(60. * 1e6 / microsPerBeat.count())
+    : mValue(60. * 1e6 / microsPerBeat.count())
   {
   }
 
   double bpm() const
   {
-    return std::get<0>(*this);
+    return mValue;
   }
 
   std::chrono::microseconds microsPerBeat() const
   {
-    return std::chrono::microseconds{llround(60. * 1e6 / bpm())};
+    return std::chrono::microseconds{std::llround(60. * 1e6 / bpm())};
   }
 
   // Given the tempo, convert a time to a beat value
@@ -61,7 +61,7 @@ struct Tempo : std::tuple<double>
   // Given the tempo, convert a beat to a time value
   std::chrono::microseconds beatsToMicros(const Beats beats) const
   {
-    return std::chrono::microseconds{llround(beats.floating() * microsPerBeat().count())};
+    return std::chrono::microseconds{std::llround(beats.floating() * microsPerBeat().count())};
   }
 
   // Model the NetworkByteStreamSerializable concept
@@ -84,6 +84,39 @@ struct Tempo : std::tuple<double>
         std::move(begin), std::move(end));
     return std::make_pair(Tempo{std::move(result.first)}, std::move(result.second));
   }
+
+  friend bool operator==(const Tempo lhs, const Tempo rhs)
+  {
+    return lhs.mValue == rhs.mValue;
+  }
+
+  friend bool operator!=(const Tempo lhs, const Tempo rhs)
+  {
+      return lhs.mValue != rhs.mValue;
+  }
+
+  friend bool operator<(const Tempo lhs, const Tempo rhs)
+  {
+      return lhs.mValue < rhs.mValue;
+  }
+
+  friend bool operator>(const Tempo lhs, const Tempo rhs)
+  {
+      return lhs.mValue > rhs.mValue;
+  }
+
+  friend bool operator<=(const Tempo lhs, const Tempo rhs)
+  {
+      return lhs.mValue <= rhs.mValue;
+  }
+
+  friend bool operator>=(const Tempo lhs, const Tempo rhs)
+  {
+      return lhs.mValue >= rhs.mValue;
+  }
+
+private:
+    double mValue = 0;
 };
 
 } // namespace link


### PR DESCRIPTION
Inheriting std::tuple<> made the code complex and led to compilation
error when doing std::get<0>(*this);