### PR TITLE
Fix use-after-scope found by ASAN in the test suite

### DIFF
--- a/src/ableton/link/tst_Peers.cpp
+++ b/src/ableton/link/tst_Peers.cpp
@@ -116,10 +116,10 @@ TEST_CASE("Peers | EmptySessionPeersAfterInit", "[Peers]")
 
 TEST_CASE("Peers | AddAndFindPeer", "[Peers]")
 {
-  test::serial_io::Fixture io;
   auto membership = SessionMembershipCallback{};
   auto sessions = SessionTimelineCallback{};
   auto startStops = SessionStartStopStateCallback{};
+  test::serial_io::Fixture io;
   auto peers = makePeers(util::injectVal(io.makeIoContext()), std::ref(membership),
     std::ref(sessions), std::ref(startStops));
   auto observer = makeGatewayObserver(peers, gateway1);
@@ -136,8 +136,8 @@ TEST_CASE("Peers | AddAndFindPeer", "[Peers]")
 
 TEST_CASE("Peers | AddAndRemovePeer", "[Peers]")
 {
-  test::serial_io::Fixture io;
   auto membership = SessionMembershipCallback{};
+  test::serial_io::Fixture io;
   auto peers = makePeers(util::injectVal(io.makeIoContext()), std::ref(membership),
     SessionTimelineCallback{}, SessionStartStopStateCallback{});
   auto observer = makeGatewayObserver(peers, gateway1);
@@ -152,10 +152,10 @@ TEST_CASE("Peers | AddAndRemovePeer", "[Peers]")
 
 TEST_CASE("Peers | AddTwoPeersRemoveOne", "[Peers]")
 {
-  test::serial_io::Fixture io;
   auto membership = SessionMembershipCallback{};
   auto sessions = SessionTimelineCallback{};
   auto startStops = SessionStartStopStateCallback{};
+  test::serial_io::Fixture io;
   auto peers = makePeers(util::injectVal(io.makeIoContext()), std::ref(membership),
     std::ref(sessions), std::ref(startStops));
   auto observer = makeGatewayObserver(peers, gateway1);
@@ -172,10 +172,10 @@ TEST_CASE("Peers | AddTwoPeersRemoveOne", "[Peers]")
 
 TEST_CASE("Peers | AddThreePeersTwoOnSameGateway", "[Peers]")
 {
-  test::serial_io::Fixture io;
   auto membership = SessionMembershipCallback{};
   auto sessions = SessionTimelineCallback{};
   auto startStops = SessionStartStopStateCallback{};
+  test::serial_io::Fixture io;
   auto peers = makePeers(util::injectVal(io.makeIoContext()), std::ref(membership),
     std::ref(sessions), std::ref(startStops));
   auto observer1 = makeGatewayObserver(peers, gateway1);
@@ -194,10 +194,10 @@ TEST_CASE("Peers | AddThreePeersTwoOnSameGateway", "[Peers]")
 
 TEST_CASE("Peers | CloseGateway", "[Peers]")
 {
-  test::serial_io::Fixture io;
   auto membership = SessionMembershipCallback{};
   auto sessions = SessionTimelineCallback{};
   auto startStops = SessionStartStopStateCallback{};
+  test::serial_io::Fixture io;
   auto peers = makePeers(util::injectVal(io.makeIoContext()), std::ref(membership),
     std::ref(sessions), std::ref(startStops));
   auto observer1 = makeGatewayObserver(peers, gateway1);


### PR DESCRIPTION
```20-08-07 15:03:31 1 abique@knot:~/d/b/l/build git:master> ninja && bin/LinkCoreTest 
[2/2] Linking CXX executable bin/LinkCoreTest
=================================================================
==6242==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7fffe2d6bc10 at pc 0x55c74407a801 bp 0x7fffe2d6b4d0 sp 0x7fffe2d6b4c8
READ of size 8 at 0x7fffe2d6bc10 thread T0
    #0 0x55c74407a800 in ableton::link::(anonymous namespace)::SessionMembershipCallback::operator()() /home/abique/develop/bitwig/link/build/../src/ableton/link/tst_Peers.cpp:38:5
    #1 0x55c74407a7bc in void std::__invoke_impl<void, ableton::link::(anonymous namespace)::SessionMembershipCallback&>(std::__invoke_other, ableton::link::(anonymous namespace)::SessionMembershipCallback&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.1.0/../../../../include/c++/10.1.0/bits/invoke.h:60:14
    #2 0x55c74407a74c in std::__invoke_result<ableton::link::(anonymous namespace)::SessionMembershipCallback&>::type std::__invoke<ableton::link::(anonymous namespace)::SessionMembershipCallback&>(ableton::link::(anonymous namespace)::SessionMembershipCallback&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.1.0/../../../../include/c++/10.1.0/bits/invoke.h:95:14
    #3 0x55c7440702ec in std::result_of<ableton::link::(anonymous namespace)::SessionMembershipCallback& ()>::type std::reference_wrapper<ableton::link::(anonymous namespace)::SessionMembershipCallback>::operator()<>() const /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.1.0/../../../../include/c++/10.1.0/bits/refwrap.h:349:11
    #4 0x55c744092997 in ableton::link::Peers<ableton::test::serial_io::Context, std::reference_wrapper<ableton::link::(anonymous namespace)::SessionMembershipCallback>, ableton::link::(anonymous namespace)::SessionTimelineCallback, ableton::link::(anonymous namespace)::SessionStartStopStateCallback>::Impl::gatewayClosed(asio::ip::address const&) /home/abique/develop/bitwig/link/build/../include/ableton/link/Peers.hpp:317:7
    #5 0x55c7440924c4 in ableton::link::Peers<ableton::test::serial_io::Context, std::reference_wrapper<ableton::link::(anonymous namespace)::SessionMembershipCallback>, ableton::link::(anonymous namespace)::SessionTimelineCallback, ableton::link::(anonymous namespace)::SessionStartStopStateCallback>::GatewayObserver::Deleter::operator()() /home/abique/develop/bitwig/link/build/../include/ableton/link/Peers.hpp:182:17
    #6 0x55c74409246c in void std::__invoke_impl<void, ableton::link::Peers<ableton::test::serial_io::Context, std::reference_wrapper<ableton::link::(anonymous namespace)::SessionMembershipCallback>, ableton::link::(anonymous namespace)::SessionTimelineCallback, ableton::link::(anonymous namespace)::SessionStartStopStateCallback>::GatewayObserver::Deleter&>(std::__invoke_other, ableton::link::Peers<ableton::test::serial_io::Context, std::reference_wrapper<ableton::link::(anonymous namespace)::SessionMembershipCallback>, ableton::link::(anonymous namespace)::SessionTimelineCallback, ableton::link::(anonymous namespace)::SessionStartStopStateCallback>::GatewayObserver::Deleter&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.1.0/../../../../include/c++/10.1.0/bits/invoke.h:60:14
    #7 0x55c7440923ec in std::enable_if<__and_<std::is_void<void>, std::__is_invocable<ableton::link::Peers<ableton::test::serial_io::Context, std::reference_wrapper<ableton::link::(anonymous namespace)::SessionMembershipCallback>, ableton::link::(anonymous namespace)::SessionTimelineCallback, ableton::link::(anonymous namespace)::SessionStartStopStateCallback>::GatewayObserver::Deleter&> >::value, void>::type std::__invoke_r<void, ableton::link::Peers<ableton::test::serial_io::Context, std::reference_wrapper<ableton::link::(anonymous namespace)::SessionMembershipCallback>, ableton::link::(anonymous namespace)::SessionTimelineCallback, ableton::link::(anonymous namespace)::SessionStartStopStateCallback>::GatewayObserver::Deleter&>(ableton::link::Peers<ableton::test::serial_io::Context, std::reference_wrapper<ableton::link::(anonymous namespace)::SessionMembershipCallback>, ableton::link::(anonymous namespace)::SessionTimelineCallback, ableton::link::(anonymous namespace)::SessionStartStopStateCallback>::GatewayObserver::Deleter&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.1.0/../../../../include/c++/10.1.0/bits/invoke.h:153:7
    #8 0x55c74409224c in std::_Function_handler<void (), ableton::link::Peers<ableton::test::serial_io::Context, std::reference_wrapper<ableton::link::(anonymous namespace)::SessionMembershipCallback>, ableton::link::(anonymous namespace)::SessionTimelineCallback, ableton::link::(anonymous namespace)::SessionStartStopStateCallback>::GatewayObserver::Deleter>::_M_invoke(std::_Any_data const&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.1.0/../../../../include/c++/10.1.0/bits/std_function.h:291:9
    #9 0x55c743ff1d80 in std::function<void ()>::operator()() const /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.1.0/../../../../include/c++/10.1.0/bits/std_function.h:622:14
    #10 0x55c7441f0c40 in ableton::test::serial_io::SchedulerTree::handlePending() /home/abique/develop/bitwig/link/build/../src/ableton/test/serial_io/SchedulerTree.cpp:95:5
    #11 0x55c7441f09fc in ableton::test::serial_io::SchedulerTree::run() /home/abique/develop/bitwig/link/build/../src/ableton/test/serial_io/SchedulerTree.cpp:32:10
    #12 0x55c744098c3f in ableton::test::serial_io::Fixture::flush() /home/abique/develop/bitwig/link/build/../include/ableton/test/serial_io/Fixture.hpp:65:18
    #13 0x55c744098c6b in ableton::test::serial_io::Fixture::~Fixture() /home/abique/develop/bitwig/link/build/../include/ableton/test/serial_io/Fixture.hpp:45:5
    #14 0x55c7440614bb in ableton::link::____C_A_T_C_H____T_E_S_T____4() /home/abique/develop/bitwig/link/build/../src/ableton/link/tst_Peers.cpp:151:1
    #15 0x55c74411e92c in Catch::FreeFunctionTestCase::invoke() const /home/abique/develop/bitwig/link/build/../third_party/catch/catch.hpp:7343:13
    #16 0x55c7440fa14e in Catch::TestCase::invoke() const /home/abique/develop/bitwig/link/build/../third_party/catch/catch.hpp:8341:15
    #17 0x55c7441515da in Catch::RunContext::invokeActiveTestCase() /home/abique/develop/bitwig/link/build/../third_party/catch/catch.hpp:6869:31
    #18 0x55c74415008f in Catch::RunContext::runCurrentTest(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) /home/abique/develop/bitwig/link/build/../third_party/catch/catch.hpp:6842:21
    #19 0x55c744110995 in Catch::RunContext::runTest(Catch::TestCase const&) /home/abique/develop/bitwig/link/build/../third_party/catch/catch.hpp:6634:21
    #20 0x55c7440f232c in Catch::runTests(Catch::Ptr<Catch::Config> const&) /home/abique/develop/bitwig/link/build/../third_party/catch/catch.hpp:7014:35
    #21 0x55c74419ba7b in Catch::Session::runInternal() /home/abique/develop/bitwig/link/build/../third_party/catch/catch.hpp:7186:42
    #22 0x55c74418593f in Catch::Session::run() /home/abique/develop/bitwig/link/build/../third_party/catch/catch.hpp:7145:28
    #23 0x55c74411b524 in Catch::Session::run(int, char const* const*) /home/abique/develop/bitwig/link/build/../third_party/catch/catch.hpp:7110:30
    #24 0x55c74410b5a3 in main /home/abique/develop/bitwig/link/build/../third_party/catch/catch.hpp:11390:35
    #25 0x7f4c0f2fb001 in __libc_start_main (/usr/lib/libc.so.6+0x27001)
    #26 0x55c743e080ad in _start (/home/abique/develop/bitwig/link/build/bin/LinkCoreTest+0x1590ad)

Address 0x7fffe2d6bc10 is located in stack of thread T0 at offset 112 in frame
    #0 0x55c74406081f in ableton::link::____C_A_T_C_H____T_E_S_T____4() /home/abique/develop/bitwig/link/build/../src/ableton/link/tst_Peers.cpp:138

  This frame has 19 object(s):
    [32, 80) 'io' (line 139)
    [112, 120) 'membership' (line 140) <== Memory access at offset 112 is inside this variable
    [144, 160) 'peers' (line 141)
    [176, 224) 'agg.tmp'
    [256, 304) 'agg.tmp1'
    [336, 344) 'agg.tmp4'
    [368, 392) 'agg.tmp5'
    [432, 456) 'agg.tmp6'
    [496, 544) 'observer' (line 143)
    [576, 608) 'agg.tmp10'
    [640, 648) 'ref.tmp' (line 146)
    [672, 696) 'ref.tmp23' (line 149)
    [736, 760) 'ref.tmp24' (line 149)
    [800, 808) 'ref.tmp25' (line 149)
    [832, 976) '__catchResult' (line 150)
    [1040, 1056) 'ref.tmp39' (line 150)
    [1072, 1104) 'ref.tmp44' (line 150)
    [1136, 1168) 'ref.tmp45' (line 150)
    [1200, 1204) 'ref.tmp46' (line 150)
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-use-after-scope /home/abique/develop/bitwig/link/build/../src/ableton/link/tst_Peers.cpp:38:5 in ableton::link::(anonymous namespace)::SessionMembershipCallback::operator()()
Shadow bytes around the buggy address:
  0x10007c5a5730: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10007c5a5740: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10007c5a5750: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10007c5a5760: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10007c5a5770: 00 00 00 00 f1 f1 f1 f1 00 00 00 00 00 00 f2 f2
=>0x10007c5a5780: f2 f2[f8]f2 f2 f2 f8 f8 f2 f2 00 00 00 00 00 00
  0x10007c5a5790: f2 f2 f2 f2 00 00 00 00 00 00 f2 f2 f2 f2 00 f2
  0x10007c5a57a0: f2 f2 00 00 00 f2 f2 f2 f2 f2 00 00 00 f2 f2 f2
  0x10007c5a57b0: f2 f2 f8 f8 f8 f8 f8 f8 f2 f2 f2 f2 00 00 00 00
  0x10007c5a57c0: f2 f2 f2 f2 f8 f2 f2 f2 f8 f8 f8 f2 f2 f2 f2 f2
  0x10007c5a57d0: f8 f8 f8 f2 f2 f2 f2 f2 f8 f2 f2 f2 f8 f8 f8 f8
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==6242==ABORTING

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
AddressSanitizer: nested bug in the same thread, aborting.
```