### PR TITLE
[CMake] Fixed a problem when the Catch library folder was not placed under the root of project.

### DIFF
--- a/cmake_include/CatchConfig.cmake
+++ b/cmake_include/CatchConfig.cmake
@@ -2,5 +2,5 @@ add_library(Catch::Catch IMPORTED INTERFACE)
 
 set_property(TARGET Catch::Catch APPEND PROPERTY
   INTERFACE_INCLUDE_DIRECTORIES
-  ${CMAKE_SOURCE_DIR}/third_party/catch
+  ${CMAKE_CURRENT_LIST_DIR}/../third_party/catch
 )


### PR DESCRIPTION
I found that the current description in ```CatchConfig.cmake``` does not resolve the path that references the Catch library when the project file structure is configured like below.

```txt
ProjectRoot
├── CMakeLists.txt
├── Examples
│        └── (example) 
└── External ......... Directory in which to place git submodules
          ├── link
          └── (other submodule)....... in my case, JUCE
```

For example, the ```CMakeLists.txt``` in project root has described to include the link library.

```txt
cmake_minimum_required(VERSION 3.15)

....

project(MyProject VERSION 0.0.1)

# Add Ableton Link library to this project
add_subdirectory(External/link)

# Add library from other submodule
add_subdirectory(External/(other submodule))
```

When you run Generate with CMake in the above example, you will get the following error message from CMake.

```txt
CMake Error in External/link/src/CMakeLists.txt:
  Imported target "Catch::Catch" includes non-existent path

    "(my_project_root)/third_party/catch"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```

The reason this happens is that the current ```CatchConfig.cmake``` specifies that there is the ```third_party/catch``` folder  in the same directory of ```CMakeLists.txt```, as shown below.

```txt
set_property(TARGET Catch::Catch APPEND PROPERTY
  INTERFACE_INCLUDE_DIRECTORIES
  ${CMAKE_SOURCE_DIR}/third_party/catch
)
```

The content of the proposal was based on the description in ```AsioStandaloneConfig.cmake```.
```txt
Reference from AsioStandaloneConfig.cmake

set_property(TARGET AsioStandalone::AsioStandalone APPEND PROPERTY
  INTERFACE_INCLUDE_DIRECTORIES
  ${CMAKE_CURRENT_LIST_DIR}/../modules/asio-standalone/asio/include
)
```

Please, check it.