### PR TITLE
Use timer and interrupt to notify Link task instead of portYIELD

### DIFF
--- a/include/ableton/platforms/esp32/Context.hpp
+++ b/include/ableton/platforms/esp32/Context.hpp
@@ -24,6 +24,8 @@
 #include <ableton/platforms/asio/AsioWrapper.hpp>
 #include <ableton/platforms/asio/Socket.hpp>
 #include <ableton/platforms/esp32/LockFreeCallbackDispatcher.hpp>
+#include <driver/timer.h>
+#include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
 namespace ableton
@@ -46,12 +48,26 @@ class Context
       {
         try
         {
+          ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
           runner->mpService->poll_one();
         }
         catch (...)
         {
         }
-        portYIELD();
+      }
+    }
+
+    static void IRAM_ATTR timerIsr(void* userParam)
+    {
+      static BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+
+      timer_group_clr_intr_status_in_isr(TIMER_GROUP_0, TIMER_1);
+      timer_group_enable_alarm_in_isr(TIMER_GROUP_0, TIMER_1);
+
+      vTaskNotifyGiveFromISR(userParam, &xHigherPriorityTaskWoken);
+      if (xHigherPriorityTaskWoken)
+      {
+        portYIELD_FROM_ISR();
       }
     }
 
@@ -62,6 +78,21 @@ class Context
     {
       xTaskCreatePinnedToCore(run, "link", 8192, this, 2 | portPRIVILEGE_BIT,
         &mTaskHandle, LINK_ESP_TASK_CORE_ID);
+
+      timer_config_t config = {.alarm_en = TIMER_ALARM_EN,
+        .counter_en = TIMER_PAUSE,
+        .intr_type = TIMER_INTR_LEVEL,
+        .counter_dir = TIMER_COUNT_UP,
+        .auto_reload = TIMER_AUTORELOAD_EN,
+        .divider = 80};
+
+      timer_init(TIMER_GROUP_0, TIMER_1, &config);
+      timer_set_counter_value(TIMER_GROUP_0, TIMER_1, 0);
+      timer_set_alarm_value(TIMER_GROUP_0, TIMER_1, 100);
+      timer_enable_intr(TIMER_GROUP_0, TIMER_1);
+      timer_isr_register(TIMER_GROUP_0, TIMER_1, &timerIsr, mTaskHandle, 0, nullptr);
+
+      timer_start(TIMER_GROUP_0, TIMER_1);
     }
 
     ~ServiceRunner()

--- a/include/ableton/platforms/esp32/LockFreeCallbackDispatcher.hpp
+++ b/include/ableton/platforms/esp32/LockFreeCallbackDispatcher.hpp
@@ -77,7 +77,7 @@ private:
         dispatcher->mCondition.wait_for(lock, dispatcher->mFallbackPeriod);
       }
       dispatcher->mCallback();
-      portYIELD();
+      vTaskDelay(1);
     }
   }
 


### PR DESCRIPTION
To resolve an [issue](https://github.com/mathiasbredholt/link-esp-example/issues/2) with the task watchdog being triggered, I propose to replace portYIELD() with a timer that notifies the Link task to run with a period of 100 microseconds.

Optionally it would be nice to add configuration options for which timer to use.

This PR proposes a more elegant solution to poll the Context faster than the FreeRTOS tick rate. The existing solution with using portYIELD() forces the scheduler to run after each poll, which effectively preempts all tasks running at a lower priority than the Link task (eg. the IDLE tasks which run at priority 0, lower than the Link task at priority 2). This can trigger the watchdog as the IDLE task is not allowed to run (depending on the configuration). 

By using a timer + interrupt that notifies the Link task to run, we obtain a solution that allows to poll the Context at a fixed rate that is independent of the FreeRTOS tick rate, while allowing other tasks with lower priority to run as well.

I've done tests with different update intervals and 100 microseconds seem to offer good performance, while giving time to the scheduler for running other tasks with lower priority. 