### PR TITLE
linux: clang compile fix

### DIFF
--- a/include/ableton/platforms/Config.hpp
+++ b/include/ableton/platforms/Config.hpp
@@ -78,12 +78,12 @@ using IoContext = platforms::asio::Context<platforms::posix::ScanIpIfAddrs,
 using Random = platforms::stl::Random;
 
 #elif defined(LINK_PLATFORM_LINUX)
-using Clock = platforms::linux::ClockMonotonicRaw;
+using Clock = platforms::linux_::ClockMonotonicRaw;
 using Random = platforms::stl::Random;
 #ifdef __linux__
 using IoContext = platforms::asio::Context<platforms::posix::ScanIpIfAddrs,
   util::NullLog,
-  platforms::linux::ThreadFactory>;
+  platforms::linux_::ThreadFactory>;
 #else
 using IoContext =
   platforms::asio::Context<platforms::posix::ScanIpIfAddrs, util::NullLog>;

--- a/include/ableton/platforms/linux/Clock.hpp
+++ b/include/ableton/platforms/linux/Clock.hpp
@@ -28,15 +28,11 @@ namespace ableton
 namespace platforms
 {
 
-#ifdef linux
-#undef linux
-#endif
-
 #if defined(__FreeBSD_kernel__)
 #define CLOCK_MONOTONIC_RAW CLOCK_MONOTONIC
 #endif
 
-namespace linux
+namespace linux_
 {
 
 template <clockid_t CLOCK>
@@ -55,6 +51,6 @@ public:
 using ClockMonotonic = Clock<CLOCK_MONOTONIC>;
 using ClockMonotonicRaw = Clock<CLOCK_MONOTONIC_RAW>;
 
-} // namespace linux
+} // namespace linux_
 } // namespace platforms
 } // namespace ableton

--- a/include/ableton/platforms/linux/ThreadFactory.hpp
+++ b/include/ableton/platforms/linux/ThreadFactory.hpp
@@ -26,7 +26,7 @@ namespace ableton
 {
 namespace platforms
 {
-namespace linux
+namespace linux_
 {
 
 struct ThreadFactory
@@ -40,6 +40,6 @@ struct ThreadFactory
   }
 };
 
-} // namespace linux
+} // namespace linux_
 } // namespace platforms
 } // namespace ableton


### PR DESCRIPTION
clang (15.0.7) defines `linux` as built-in, which cannot be `#undef`ed