### PR TITLE
Changes Clock::Ticks to be signed int64

### DIFF
--- a/include/ableton/platforms/darwin/Clock.hpp
+++ b/include/ableton/platforms/darwin/Clock.hpp
@@ -31,7 +31,7 @@ namespace darwin
 
 struct Clock
 {
-  using Ticks = std::uint64_t;
+  using Ticks = std::int64_t;
   using Micros = std::chrono::microseconds;
 
   Clock()


### PR DESCRIPTION
The host time in core audio callbacks is not guaranteed to be higher than an arbitrary song length, for example on the simulator right after a reboot. The mHostTime in the timestamp could be a low value compared to a beat remapping of, say, an hour into a song. Playing a song starting at the one hour mark will then cause a negative songZero, unless the computer running the simulator has been running for more than an hour. And the unsigned datatype is then misinterpreted.

This pull request changes the datatype to signed to allow for these negative anchors.