### PR TITLE
Fix floating point test failure

### DIFF
--- a/src/ableton/link/tst_LinearRegression.cpp
+++ b/src/ableton/link/tst_LinearRegression.cpp
@@ -38,8 +38,8 @@ TEST_CASE("LinearRegression")
     Array data;
     data[0] = {0., 0.};
     const auto result = linearRegression(data.begin(), data.end());
-    CHECK(0 == Approx(result.first));
-    CHECK(0 == Approx(result.second));
+    CHECK_THAT(result.first, Catch::Matchers::WithinAbs(0, 0.00001));
+    CHECK_THAT(result.second, Catch::Matchers::WithinAbs(0, 0.00001));
   }
 
   SECTION("TwoPoints")
@@ -49,8 +49,8 @@ TEST_CASE("LinearRegression")
     data.emplace_back(666666.6, 66666.6);
 
     const auto result = linearRegression(data.begin(), data.end());
-    CHECK(0.1 == Approx(result.first));
-    CHECK(0.0 == Approx(result.second));
+    CHECK_THAT(result.first, Catch::Matchers::WithinAbs(0.1, 0.00001));
+    CHECK_THAT(result.second, Catch::Matchers::WithinAbs(0.0, 0.00001));
   }
 
   SECTION("10000Points")
@@ -76,8 +76,8 @@ TEST_CASE("LinearRegression")
     data.emplace_back(666666.6f, 66666.6f);
 
     const auto result = linearRegression(data.begin(), data.end());
-    CHECK(0.1f == Approx(result.first));
-    CHECK(0.f == Approx(result.second));
+    CHECK_THAT(static_cast<double>(result.first), Catch::Matchers::WithinAbs(0.1, 0.002));
+    CHECK_THAT(static_cast<double>(result.second), Catch::Matchers::WithinAbs(0., 0.002));
   }
 
   SECTION("10000Points Float")


### PR DESCRIPTION
See https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1784.

Despite using `Approx` in floating-point, the tests fail on riscv64 because `Approx` uses relative margin comparison, and thus `0.0 == Approx(n)` will always fail for `n != 0.0`. Use new floating-point matchers for those comparing with zero (or close to zero).

`float` comparisons uses a larger margin than `double` ones.

The failure log is shown below:

```
==> Starting check()...

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
LinkCoreTest is a Catch v2.13.9 host application.
Run with -? for options

-------------------------------------------------------------------------------
LinearRegression
  TwoPoints
-------------------------------------------------------------------------------
/usr/src/debug/abletonlink/link-Link-3.0.6/src/ableton/link/tst_LinearRegression.cpp:45
...............................................................................

/usr/src/debug/abletonlink/link-Link-3.0.6/src/ableton/link/tst_LinearRegression.cpp:53: FAILED:
  CHECK( 0.0 == Approx(result.second) )
with expansion:
  0.0 == Approx( -0.0 )

-------------------------------------------------------------------------------
LinearRegression
  TwoPoints Float
-------------------------------------------------------------------------------
/usr/src/debug/abletonlink/link-Link-3.0.6/src/ableton/link/tst_LinearRegression.cpp:72
...............................................................................

/usr/src/debug/abletonlink/link-Link-3.0.6/src/ableton/link/tst_LinearRegression.cpp:80: FAILED:
  CHECK( 0.f == Approx(result.second) )
with expansion:
  0.0f == Approx( -0.0011631348 )

===============================================================================
test cases:     14 |     13 passed | 1 failed
assertions: 524519 | 524517 passed | 2 failed
```