### PR TITLE
Fix thread/realtime safety documentation errors

### DIFF
--- a/extensions/abl_link/include/abl_link.h
+++ b/extensions/abl_link/include/abl_link.h
@@ -92,13 +92,13 @@ extern "C"
 
   /*! @brief: Is start/stop synchronization enabled?
    *  Thread-safe: yes
-   *  Realtime-safe: no
+   *  Realtime-safe: yes
    */
   bool abl_link_is_start_stop_sync_enabled(abl_link link);
 
   /*! @brief: Enable start/stop synchronization.
    *  Thread-safe: yes
-   *  Realtime-safe: no
+   *  Realtime-safe: yes
    */
   void abl_link_enable_start_stop_sync(abl_link link, bool enabled);
 
@@ -209,8 +209,8 @@ extern "C"
     abl_link link, abl_link_session_state session_state);
 
   /*! @brief Capture the current Link Session State from an application thread.
-   *  Thread-safe: no
-   *  Realtime-safe: yes
+   *  Thread-safe: yes
+   *  Realtime-safe: no
    *
    *  @discussion Provides a mechanism for capturing the Link Session State from an
    *  application thread (other than the audio thread). After capturing the session_state

--- a/include/ableton/Link.hpp
+++ b/include/ableton/Link.hpp
@@ -103,13 +103,13 @@ public:
 
   /*! @brief: Is start/stop synchronization enabled?
    *  Thread-safe: yes
-   *  Realtime-safe: no
+   *  Realtime-safe: yes
    */
   bool isStartStopSyncEnabled() const;
 
   /*! @brief: Enable start/stop synchronization.
    *  Thread-safe: yes
-   *  Realtime-safe: no
+   *  Realtime-safe: yes
    */
   void enableStartStopSync(bool bEnable);
 


### PR DESCRIPTION
* `abl_link_capture_app_session_state`

Discrepancy between C and C++ docs. C++ correctly says thread safe, not realtime safe. This matches the implementation.

* `abl_link_enable_start_stop_sync`
* `abl_link_is_start_stop_sync_enabled`
* `Link::enableStartStopSync`
* `Link::isStartStopSyncEnabled`

These read/write a `std::atomic<bool>`, so both thread & realtime safe.