### PR TITLE
Add support for IPv4 subnets other than /24

### DIFF
--- a/include/ableton/discovery/AsioTypes.hpp
+++ b/include/ableton/discovery/AsioTypes.hpp
@@ -20,6 +20,8 @@
 #pragma once
 
 #include <ableton/platforms/asio/AsioWrapper.hpp>
+#include <ostream>
+#include <variant>
 
 namespace ableton
 {
@@ -29,8 +31,84 @@ namespace discovery
 using IpAddress = LINK_ASIO_NAMESPACE::ip::address;
 using IpAddressV4 = LINK_ASIO_NAMESPACE::ip::address_v4;
 using IpAddressV6 = LINK_ASIO_NAMESPACE::ip::address_v6;
+using NetworkV4 = LINK_ASIO_NAMESPACE::ip::network_v4;
 using UdpSocket = LINK_ASIO_NAMESPACE::ip::udp::socket;
 using UdpEndpoint = LINK_ASIO_NAMESPACE::ip::udp::endpoint;
+
+// An interface address is either a v4 network (address + prefix length)
+// or a bare v6 address. This bundles the prefix information that was
+// previously obtained via a separate prefixLengthForAddress() call.
+// Implemented as a struct wrapping std::variant because ASIO's NetworkV4
+// does not provide operator<, which std::variant comparison requires.
+struct InterfaceAddress
+{
+  std::variant<NetworkV4, IpAddressV6> value;
+
+  InterfaceAddress() = default;
+  InterfaceAddress(NetworkV4 net)
+    : value(std::move(net))
+  {
+  }
+  InterfaceAddress(IpAddressV6 addr)
+    : value(std::move(addr))
+  {
+  }
+
+  friend bool operator==(const InterfaceAddress& a, const InterfaceAddress& b)
+  {
+    return a.value == b.value;
+  }
+  friend bool operator!=(const InterfaceAddress& a, const InterfaceAddress& b)
+  {
+    return !(a == b);
+  }
+  friend bool operator<(const InterfaceAddress& a, const InterfaceAddress& b)
+  {
+    if (a.value.index() != b.value.index())
+    {
+      return a.value.index() < b.value.index();
+    }
+    if (auto* lhs = std::get_if<NetworkV4>(&a.value))
+    {
+      const auto& rhs = std::get<NetworkV4>(b.value);
+      if (lhs->address() != rhs.address())
+      {
+        return lhs->address() < rhs.address();
+      }
+      return lhs->prefix_length() < rhs.prefix_length();
+    }
+    return std::get<IpAddressV6>(a.value) < std::get<IpAddressV6>(b.value);
+  }
+  friend std::ostream& operator<<(std::ostream& os, const InterfaceAddress& ifAddr)
+  {
+    std::visit([&os](const auto& addr) { os << addr; }, ifAddr.value);
+    return os;
+  }
+};
+
+// Extract the IpAddress from an InterfaceAddress
+inline IpAddress toIpAddress(const InterfaceAddress& ifAddr)
+{
+  return std::visit(
+    [](const auto& addr) -> IpAddress
+    {
+      if constexpr (std::is_same_v<std::decay_t<decltype(addr)>, NetworkV4>)
+      {
+        return addr.address();
+      }
+      else
+      {
+        return addr;
+      }
+    },
+    ifAddr.value);
+}
+
+template <typename... Args>
+inline NetworkV4 makeNetworkV4(Args&&... args)
+{
+  return LINK_ASIO_NAMESPACE::ip::make_network_v4(std::forward<Args>(args)...);
+}
 
 template <typename... Args>
 inline IpAddress makeAddress(Args&&... args)

--- a/include/ableton/discovery/InterfaceScanner.hpp
+++ b/include/ableton/discovery/InterfaceScanner.hpp
@@ -29,7 +29,7 @@ namespace ableton
 namespace discovery
 {
 
-// Callback takes a range of IpAddress which is
+// Callback takes a range of InterfaceAddress which is
 // guaranteed to be sorted and unique
 template <typename Callback, typename IoContext>
 class InterfaceScanner
@@ -64,7 +64,7 @@ public:
     using namespace std;
     debug(mIo->log()) << "Scanning network interfaces";
     // Rescan the hardware for available network interface addresses
-    vector<IpAddress> addrs = mIo->scanNetworkInterfaces();
+    vector<InterfaceAddress> addrs = mIo->scanNetworkInterfaces();
     // Sort and unique them to guarantee consistent comparison
     sort(begin(addrs), end(addrs));
     addrs.erase(unique(begin(addrs), end(addrs)), end(addrs));

--- a/include/ableton/discovery/IpInterface.hpp
+++ b/include/ableton/discovery/IpInterface.hpp
@@ -21,6 +21,7 @@
 
 #include <ableton/discovery/AsioTypes.hpp>
 #include <ableton/util/Injected.hpp>
+#include <optional>
 
 namespace ableton
 {
@@ -52,10 +53,14 @@ class IpInterface
 public:
   using Socket = typename util::Injected<IoContext>::type::template Socket<MaxPacketSize>;
 
-  IpInterface(util::Injected<IoContext> io, const IpAddress& addr)
+  IpInterface(util::Injected<IoContext> io, const InterfaceAddress& ifAddr)
     : mIo(std::move(io))
-    , mMulticastReceiveSocket(mIo->template openMulticastSocket<MaxPacketSize>(addr))
-    , mSendSocket(mIo->template openUnicastSocket<MaxPacketSize>(addr))
+    , mMulticastReceiveSocket(
+        mIo->template openMulticastSocket<MaxPacketSize>(toIpAddress(ifAddr)))
+    , mSendSocket(mIo->template openUnicastSocket<MaxPacketSize>(toIpAddress(ifAddr)))
+    , mSubnetV4(std::holds_alternative<NetworkV4>(ifAddr.value)
+                  ? std::optional<NetworkV4>{std::get<NetworkV4>(ifAddr.value)}
+                  : std::nullopt)
   {
   }
 
@@ -66,6 +71,7 @@ public:
     : mIo(std::move(rhs.mIo))
     , mMulticastReceiveSocket(std::move(rhs.mMulticastReceiveSocket))
     , mSendSocket(std::move(rhs.mSendSocket))
+    , mSubnetV4(rhs.mSubnetV4)
   {
   }
 
@@ -92,6 +98,8 @@ public:
 
   UdpEndpoint endpoint() const { return mSendSocket.endpoint(); }
 
+  const std::optional<NetworkV4>& subnetV4() const { return mSubnetV4; }
+
 private:
   template <typename Tag, typename Handler>
   struct SocketReceiver
@@ -113,13 +121,14 @@ private:
   util::Injected<IoContext> mIo;
   Socket mMulticastReceiveSocket;
   Socket mSendSocket;
+  std::optional<NetworkV4> mSubnetV4;
 };
 
 template <std::size_t MaxPacketSize, typename IoContext>
 IpInterface<IoContext, MaxPacketSize> makeIpInterface(util::Injected<IoContext> io,
-                                                      const IpAddress& addr)
+                                                      const InterfaceAddress& ifAddr)
 {
-  return {std::move(io), addr};
+  return {std::move(io), ifAddr};
 }
 
 } // namespace discovery

--- a/include/ableton/discovery/PeerGateway.hpp
+++ b/include/ableton/discovery/PeerGateway.hpp
@@ -230,7 +230,7 @@ using Gateway =
 template <typename PeerObserver, typename NodeState, typename IoContext>
 Gateway<PeerObserver, NodeState, IoContext> makeGateway(
   util::Injected<IoContext> io,
-  const IpAddress& addr,
+  const InterfaceAddress& ifAddr,
   util::Injected<PeerObserver> observer,
   NodeState state)
 {
@@ -240,7 +240,7 @@ Gateway<PeerObserver, NodeState, IoContext> makeGateway(
   const uint8_t ttl = 5;
   const uint8_t ttlRatio = 20;
 
-  auto iface = makeIpInterface<v1::kMaxMessageSize>(injectRef(*io), addr);
+  auto iface = makeIpInterface<v1::kMaxMessageSize>(injectRef(*io), ifAddr);
 
   auto messenger = makeUdpMessenger(
     injectVal(std::move(iface)), std::move(state), injectRef(*io), ttl, ttlRatio);

--- a/include/ableton/discovery/PeerGateways.hpp
+++ b/include/ableton/discovery/PeerGateways.hpp
@@ -21,6 +21,7 @@
 
 #include <ableton/discovery/AsioTypes.hpp>
 #include <ableton/discovery/InterfaceScanner.hpp>
+#include <algorithm>
 #include <map>
 
 namespace ableton
@@ -39,8 +40,8 @@ public:
   using Gateway = std::invoke_result_t<FactoryType,
                                        NodeState,
                                        util::Injected<IoType&>,
-                                       const discovery::IpAddress&>;
-  using GatewayMap = std::map<IpAddress, Gateway>;
+                                       const discovery::InterfaceAddress&>;
+  using GatewayMap = std::map<InterfaceAddress, Gateway>;
 
   PeerGateways(const std::chrono::seconds rescanPeriod,
                NodeState state,
@@ -92,8 +93,13 @@ public:
   // this method can be invoked to either fix it or discard it.
   void repairGateway(const IpAddress& gatewayAddr)
   {
-    if (mpScannerCallback->mGateways.erase(gatewayAddr))
+    auto it = std::find_if(mpScannerCallback->mGateways.begin(),
+                           mpScannerCallback->mGateways.end(),
+                           [&gatewayAddr](const auto& vt)
+                           { return toIpAddress(vt.first) == gatewayAddr; });
+    if (it != mpScannerCallback->mGateways.end())
     {
+      mpScannerCallback->mGateways.erase(it);
       mpScannerCallback->mFactory->gatewaysChanged();
       // If we erased a gateway, rescan again immediately so that
       // we will re-initialize it if it's still present
@@ -116,7 +122,7 @@ private:
     {
       using namespace std;
       // Get the set of current addresses.
-      vector<IpAddress> curAddrs;
+      vector<InterfaceAddress> curAddrs;
       curAddrs.reserve(mGateways.size());
       transform(std::begin(mGateways),
                 std::end(mGateways),
@@ -125,14 +131,14 @@ private:
 
       // Now use set_difference to determine the set of addresses that
       // are new and the set of cur addresses that are no longer there
-      vector<IpAddress> newAddrs;
+      vector<InterfaceAddress> newAddrs;
       set_difference(std::begin(range),
                      std::end(range),
                      std::begin(curAddrs),
                      std::end(curAddrs),
                      back_inserter(newAddrs));
 
-      vector<IpAddress> staleAddrs;
+      vector<InterfaceAddress> staleAddrs;
       set_difference(std::begin(curAddrs),
                      std::end(curAddrs),
                      std::begin(range),

--- a/include/ableton/discovery/UdpMessenger.hpp
+++ b/include/ableton/discovery/UdpMessenger.hpp
@@ -287,13 +287,10 @@ private:
         // check if the message is coming from an endpoint that is in the same subnet as
         // the interface.
         auto ignoreIpV4Message = false;
-        if (from.address().is_v4() && mInterface->endpoint().address().is_v4())
+        if (from.address().is_v4() && mInterface->subnetV4())
         {
-          const auto subnet = LINK_ASIO_NAMESPACE::ip::make_network_v4(
-            mInterface->endpoint().address().to_v4(), 24);
-          const auto fromAddr =
-            LINK_ASIO_NAMESPACE::ip::make_network_v4(from.address().to_v4(), 32);
-          ignoreIpV4Message = !fromAddr.is_subnet_of(subnet);
+          const auto fromAddr = makeNetworkV4(from.address().to_v4(), 32);
+          ignoreIpV4Message = !fromAddr.is_subnet_of(*mInterface->subnetV4());
         }
 
         if (!ignoreIpV4Message)

--- a/include/ableton/discovery/test/Interface.hpp
+++ b/include/ableton/discovery/test/Interface.hpp
@@ -22,6 +22,8 @@
 #include <ableton/discovery/AsioTypes.hpp>
 #include <ableton/util/Log.hpp>
 #include <functional>
+#include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -37,8 +39,9 @@ class Interface
 public:
   Interface() = default;
 
-  Interface(UdpEndpoint endpoint)
-    : mEndpoint(std::move(endpoint))
+  Interface(const std::string& cidr, uint16_t port)
+    : mSubnetV4(makeNetworkV4(cidr))
+    , mEndpoint(IpAddress(mSubnetV4->address()), port)
   {
   }
 
@@ -74,6 +77,8 @@ public:
 
   UdpEndpoint endpoint() const { return mEndpoint; }
 
+  const std::optional<NetworkV4>& subnetV4() const { return mSubnetV4; }
+
   using SentMessage = std::pair<std::vector<uint8_t>, UdpEndpoint>;
   std::vector<SentMessage> sentMessages;
 
@@ -81,6 +86,7 @@ private:
   using ReceiveCallback =
     std::function<void(const UdpEndpoint&, const std::vector<uint8_t>&)>;
   ReceiveCallback mCallback;
+  std::optional<NetworkV4> mSubnetV4;
   UdpEndpoint mEndpoint;
 };
 

--- a/include/ableton/link/Controller.hpp
+++ b/include/ableton/link/Controller.hpp
@@ -716,8 +716,10 @@ protected:
       [peer, handler](auto begin, const auto end)
       {
         const auto addr = peer.second;
-        const auto it =
-          std::find_if(begin, end, [&addr](const auto& vt) { return vt.first == addr; });
+        const auto it = std::find_if(
+          begin,
+          end,
+          [&addr](const auto& vt) { return discovery::toIpAddress(vt.first) == addr; });
         if (it != end)
         {
           it->second->measurePeer(std::move(peer.first), std::move(handler));
@@ -786,15 +788,16 @@ protected:
   {
     GatewayPtr operator()(std::pair<NodeState, GhostXForm> state,
                           util::Injected<IoType&> io,
-                          const discovery::IpAddress& addr)
+                          const discovery::InterfaceAddress& ifAddr)
     {
-      return GatewayPtr{new ControllerGateway{
-        std::move(io),
-        addr,
-        util::injectVal(makeGatewayObserver(mpController->mPeers, addr)),
-        std::move(state.first),
-        std::move(state.second),
-        mpController->mClock}};
+      return GatewayPtr{
+        new ControllerGateway{std::move(io),
+                              ifAddr,
+                              util::injectVal(makeGatewayObserver(
+                                mpController->mPeers, discovery::toIpAddress(ifAddr))),
+                              std::move(state.first),
+                              std::move(state.second),
+                              mpController->mClock}};
     }
 
     void gatewaysChanged()

--- a/include/ableton/link/Gateway.hpp
+++ b/include/ableton/link/Gateway.hpp
@@ -35,14 +35,14 @@ class Gateway
 {
 public:
   Gateway(util::Injected<IoContext> io,
-          discovery::IpAddress addr,
+          discovery::InterfaceAddress ifAddr,
           util::Injected<PeerObserver> observer,
           NodeState nodeState,
           GhostXForm ghostXForm,
           Clock clock,
           std::optional<discovery::UdpEndpoint> audioEndpoint = std::nullopt)
     : mIo(std::move(io))
-    , mMeasurement(addr,
+    , mMeasurement(discovery::toIpAddress(ifAddr),
                    nodeState.sessionId,
                    std::move(ghostXForm),
                    std::move(clock),
@@ -50,7 +50,7 @@ public:
     , moAudioEndpoint(audioEndpoint)
     , mPeerGateway(discovery::makeGateway(
         util::injectRef(*mIo),
-        std::move(addr),
+        std::move(ifAddr),
         std::move(observer),
         PeerState{std::move(nodeState), mMeasurement.endpoint(), moAudioEndpoint}))
   {

--- a/include/ableton/link_audio/Controller.hpp
+++ b/include/ableton/link_audio/Controller.hpp
@@ -203,7 +203,12 @@ protected:
     auto gateways = std::vector<discovery::IpAddress>();
     this->mDiscovery.withGateways(
       [&](auto begin, auto end)
-      { std::for_each(begin, end, [&](auto& it) { gateways.push_back(it.first); }); });
+      {
+        std::for_each(begin,
+                      end,
+                      [&](auto& it)
+                      { gateways.push_back(discovery::toIpAddress(it.first)); });
+      });
 
     if (mIsLinkAudioEffectivlyEnabled)
     {
@@ -221,23 +226,25 @@ protected:
     this->mDiscovery.withGateways(
       [&](auto begin, auto end)
       {
-        std::for_each(begin,
-                      end,
-                      [&](auto& gateway)
-                      {
-                        auto it = std::find_if(endpoints.begin(),
-                                               endpoints.end(),
-                                               [&](const auto& ep)
-                                               { return ep.address() == gateway.first; });
-                        if (it != endpoints.end())
-                        {
-                          gateway.second->updateAudioEndpoint(*it);
-                        }
-                        else
-                        {
-                          gateway.second->updateAudioEndpoint(std::nullopt);
-                        }
-                      });
+        std::for_each(
+          begin,
+          end,
+          [&](auto& gateway)
+          {
+            auto it = std::find_if(
+              endpoints.begin(),
+              endpoints.end(),
+              [&](const auto& ep)
+              { return ep.address() == discovery::toIpAddress(gateway.first); });
+            if (it != endpoints.end())
+            {
+              gateway.second->updateAudioEndpoint(*it);
+            }
+            else
+            {
+              gateway.second->updateAudioEndpoint(std::nullopt);
+            }
+          });
       });
     this->updateDiscovery();
   }

--- a/include/ableton/platforms/asio/Context.hpp
+++ b/include/ableton/platforms/asio/Context.hpp
@@ -200,7 +200,10 @@ public:
     return socket;
   }
 
-  std::vector<discovery::IpAddress> scanNetworkInterfaces() { return mScanIpIfAddrs(); }
+  std::vector<discovery::InterfaceAddress> scanNetworkInterfaces()
+  {
+    return mScanIpIfAddrs();
+  }
 
   Timer makeTimer() const { return {*mpService}; }
 

--- a/include/ableton/platforms/esp32/Context.hpp
+++ b/include/ableton/platforms/esp32/Context.hpp
@@ -188,7 +188,10 @@ public:
     return socket;
   }
 
-  std::vector<::asio::ip::address> scanNetworkInterfaces() { return mScanIpIfAddrs(); }
+  std::vector<discovery::InterfaceAddress> scanNetworkInterfaces()
+  {
+    return mScanIpIfAddrs();
+  }
 
   Timer makeTimer() const { return {serviceRunner().service()}; }
 

--- a/include/ableton/platforms/esp32/ScanIpIfAddrs.hpp
+++ b/include/ableton/platforms/esp32/ScanIpIfAddrs.hpp
@@ -33,9 +33,9 @@ namespace esp32
 // ESP32 implementation of ip interface address scanner
 struct ScanIpIfAddrs
 {
-  std::vector<discovery::IpAddress> operator()()
+  std::vector<discovery::InterfaceAddress> operator()()
   {
-    std::vector<discovery::IpAddress> addrs;
+    std::vector<discovery::InterfaceAddress> addrs;
     // Get first network interface
     esp_netif_t* esp_netif = esp_netif_next(NULL);
     while (esp_netif)
@@ -45,7 +45,10 @@ struct ScanIpIfAddrs
       {
         esp_netif_ip_info_t ip_info;
         esp_netif_get_ip_info(esp_netif, &ip_info);
-        addrs.emplace_back(::asio::ip::address_v4(ntohl(ip_info.ip.addr)));
+        const auto address = ::asio::ip::address_v4(ntohl(ip_info.ip.addr));
+        const auto prefix =
+          static_cast<uint8_t>(__builtin_popcount(ntohl(ip_info.netmask.addr)));
+        addrs.emplace_back(discovery::makeNetworkV4(address, prefix));
       }
       // Get next network interface
       esp_netif = esp_netif_next(esp_netif);

--- a/include/ableton/platforms/posix/ScanIpIfAddrs.hpp
+++ b/include/ableton/platforms/posix/ScanIpIfAddrs.hpp
@@ -22,8 +22,8 @@
 #include <ableton/discovery/AsioTypes.hpp>
 #include <arpa/inet.h>
 #include <ifaddrs.h>
-#include <map>
 #include <net/if.h>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -76,10 +76,10 @@ struct ScanIpIfAddrs
 {
   // Scan active network interfaces and return corresponding addresses
   // for all ip-based interfaces.
-  std::vector<discovery::IpAddress> operator()()
+  std::vector<discovery::InterfaceAddress> operator()()
   {
-    std::vector<discovery::IpAddress> addrs;
-    std::map<std::string, discovery::IpAddress> IpInterfaceNames;
+    std::vector<discovery::InterfaceAddress> addrs;
+    std::set<std::string> IpInterfaceNames;
 
     detail::GetIfAddrs getIfAddrs;
     getIfAddrs.withIfAddrs(
@@ -95,8 +95,16 @@ struct ScanIpIfAddrs
             const auto bytes = reinterpret_cast<const char*>(&addr->sin_addr);
             const auto address =
               discovery::makeAddressFromBytes<discovery::IpAddressV4>(bytes);
-            addrs.emplace_back(address);
-            IpInterfaceNames.insert(std::make_pair(interface->ifa_name, address));
+            uint8_t prefix = 0;
+            if (interface->ifa_netmask)
+            {
+              const auto mask =
+                reinterpret_cast<const struct sockaddr_in*>(interface->ifa_netmask);
+              prefix =
+                static_cast<uint8_t>(__builtin_popcount(ntohl(mask->sin_addr.s_addr)));
+            }
+            addrs.emplace_back(discovery::makeNetworkV4(address, prefix));
+            IpInterfaceNames.insert(interface->ifa_name);
           }
         }
       });

--- a/include/ableton/platforms/windows/ScanIpIfAddrs.hpp
+++ b/include/ableton/platforms/windows/ScanIpIfAddrs.hpp
@@ -21,7 +21,7 @@
 
 #include <ableton/discovery/AsioTypes.hpp>
 #include <iphlpapi.h>
-#include <map>
+#include <set>
 #include <stdio.h>
 #include <string>
 #include <vector>
@@ -103,10 +103,10 @@ struct ScanIpIfAddrs
 {
   // Scan active network interfaces and return corresponding addresses
   // for all ip-based interfaces.
-  std::vector<discovery::IpAddress> operator()()
+  std::vector<discovery::InterfaceAddress> operator()()
   {
-    std::vector<discovery::IpAddress> addrs;
-    std::map<std::string, discovery::IpAddress> IpInterfaceNames;
+    std::vector<discovery::InterfaceAddress> addrs;
+    std::set<std::string> IpInterfaceNames;
 
     detail::GetIfAddrs getIfAddrs;
     getIfAddrs.withIfAddrs(
@@ -130,9 +130,9 @@ struct ScanIpIfAddrs
               const auto bytes = reinterpret_cast<const char*>(&addr4->sin_addr);
               const auto ipv4address =
                 discovery::makeAddressFromBytes<discovery::IpAddressV4>(bytes);
-              addrs.emplace_back(ipv4address);
-              IpInterfaceNames.insert(
-                std::make_pair(networkInterface->AdapterName, ipv4address));
+              const auto prefix = static_cast<uint8_t>(address->OnLinkPrefixLength);
+              addrs.emplace_back(discovery::makeNetworkV4(ipv4address, prefix));
+              IpInterfaceNames.insert(networkInterface->AdapterName);
             }
           }
         }

--- a/include/ableton/test/serial_io/Context.hpp
+++ b/include/ableton/test/serial_io/Context.hpp
@@ -37,7 +37,7 @@ class Context
 {
 public:
   Context(const SchedulerTree::TimePoint& now,
-          const std::vector<discovery::IpAddress>& ifAddrs,
+          const std::vector<discovery::InterfaceAddress>& ifAddrs,
           std::shared_ptr<SchedulerTree> pScheduler)
     : mNow(now)
     , mIfAddrs(ifAddrs)
@@ -83,11 +83,11 @@ public:
 
   Log& log() { return mLog; }
 
-  std::vector<discovery::IpAddress> scanNetworkInterfaces() { return mIfAddrs; }
+  std::vector<discovery::InterfaceAddress> scanNetworkInterfaces() { return mIfAddrs; }
 
 private:
   const SchedulerTree::TimePoint& mNow;
-  const std::vector<discovery::IpAddress>& mIfAddrs;
+  const std::vector<discovery::InterfaceAddress>& mIfAddrs;
   std::shared_ptr<SchedulerTree> mpScheduler;
   Log mLog;
   SchedulerTree::TimerId mNextTimerId;

--- a/include/ableton/test/serial_io/Fixture.hpp
+++ b/include/ableton/test/serial_io/Fixture.hpp
@@ -47,7 +47,7 @@ public:
   Fixture(Fixture&&) = delete;
   Fixture& operator=(Fixture&&) = delete;
 
-  void setNetworkInterfaces(std::vector<discovery::IpAddress> ifAddrs)
+  void setNetworkInterfaces(std::vector<discovery::InterfaceAddress> ifAddrs)
   {
     mIfAddrs = std::move(ifAddrs);
   }
@@ -75,7 +75,7 @@ public:
 private:
   std::shared_ptr<SchedulerTree> mpScheduler;
   SchedulerTree::TimePoint mNow;
-  std::vector<discovery::IpAddress> mIfAddrs;
+  std::vector<discovery::InterfaceAddress> mIfAddrs;
 };
 
 } // namespace serial_io

--- a/src/ableton/discovery/tst_InterfaceScanner.cpp
+++ b/src/ableton/discovery/tst_InterfaceScanner.cpp
@@ -36,15 +36,17 @@ struct TestCallback
     addrRanges.emplace_back(begin(addrs), end(addrs));
   }
 
-  std::vector<std::vector<discovery::IpAddress>> addrRanges;
+  std::vector<std::vector<discovery::InterfaceAddress>> addrRanges;
 };
 
 } // anonymous namespace
 
 TEST_CASE("InterfaceScanner")
 {
-  const auto addr1 = discovery::makeAddress("123.123.123.1");
-  const auto addr2 = discovery::makeAddress("123.123.123.2");
+  const auto addr1 =
+    discovery::InterfaceAddress{discovery::makeNetworkV4("123.123.123.1/24")};
+  const auto addr2 =
+    discovery::InterfaceAddress{discovery::makeNetworkV4("123.123.123.2/24")};
 
   test::serial_io::Fixture io;
   auto callback = TestCallback{};

--- a/src/ableton/discovery/tst_PeerGateways.cpp
+++ b/src/ableton/discovery/tst_PeerGateways.cpp
@@ -31,7 +31,7 @@ namespace
 
 struct Gateway
 {
-  IpAddress addr;
+  InterfaceAddress addr;
 };
 
 struct NodeState
@@ -41,7 +41,7 @@ struct NodeState
 struct Factory
 {
   template <typename IoContext>
-  Gateway operator()(NodeState, util::Injected<IoContext>, const IpAddress& addr)
+  Gateway operator()(NodeState, util::Injected<IoContext>, const InterfaceAddress& addr)
   {
     return {addr};
   }
@@ -55,7 +55,7 @@ struct Factory
 template <typename Gateways>
 void expectGateways(Gateways& gateways,
                     test::serial_io::Fixture& io,
-                    std::vector<IpAddress> addrs)
+                    std::vector<InterfaceAddress> addrs)
 
 {
   using namespace std;
@@ -81,8 +81,8 @@ void expectGateways(Gateways& gateways,
 
 TEST_CASE("PeerGateways")
 {
-  const IpAddress addr1 = makeAddress("192.192.192.1");
-  const IpAddress addr2 = makeAddress("192.192.192.2");
+  const InterfaceAddress addr1 = InterfaceAddress{makeNetworkV4("192.192.192.1/24")};
+  const InterfaceAddress addr2 = InterfaceAddress{makeNetworkV4("192.192.192.2/24")};
 
   test::serial_io::Fixture io;
   auto factory = Factory{};

--- a/src/ableton/discovery/tst_UdpMessenger.cpp
+++ b/src/ableton/discovery/tst_UdpMessenger.cpp
@@ -96,7 +96,7 @@ TEST_CASE("UdpMessenger")
   const auto state2 = TestNodeState{3, 10};
   const auto peerEndpoint = UdpEndpoint{makeAddress("123.123.234.234"), 1900};
   ::ableton::test::serial_io::Fixture io;
-  auto iface = test::Interface(UdpEndpoint{makeAddress("123.123.234.42"), 1234});
+  auto iface = test::Interface("123.123.234.42/24", 1234);
 
   SECTION("BroadcastsStateOnConstruction")
   {
@@ -235,6 +235,52 @@ TEST_CASE("UdpMessenger")
 
     // Received message should not be handled
     CHECK(0 == handler.peerStates.size());
+  }
+
+  SECTION("DropMessageFromDifferentSlash24")
+  {
+    // Peer IP shares the first two octets but is in a different /24 subnet
+    auto tmpMessenger = makeUdpMessenger(
+      util::injectRef(iface), TestNodeState{}, util::injectVal(io.makeIoContext()), 1, 1);
+    auto messenger = std::move(tmpMessenger);
+    auto handler = TestHandler{};
+    messenger.receive(std::ref(handler));
+
+    v1::MessageBuffer buffer;
+    const auto messageEnd =
+      v1::aliveMessage(state1.ident(), 0, makePayload(), begin(buffer));
+    iface.incomingMessage(
+      UdpEndpoint{makeAddress("123.123.235.1"), 1900}, begin(buffer), messageEnd);
+
+    CHECK(0 == handler.peerStates.size());
+  }
+
+  SECTION("AcceptMessageFromFirstAndLastUsableHostsInSlash16")
+  {
+    // Interface on a /16 subnet; peers at first and last usable host addresses
+    auto wideIface = test::Interface("123.123.123.42/16", 1234);
+    auto tmpMessenger = makeUdpMessenger(util::injectRef(wideIface),
+                                         TestNodeState{},
+                                         util::injectVal(io.makeIoContext()),
+                                         1,
+                                         1);
+    auto messenger = std::move(tmpMessenger);
+    auto handler = TestHandler{};
+
+    v1::MessageBuffer buffer;
+    auto end = v1::aliveMessage(state1.nodeId, 3, toPayload(state1), begin(buffer));
+    messenger.receive(std::ref(handler));
+    wideIface.incomingMessage(
+      UdpEndpoint{makeAddress("123.123.0.1"), 1900}, begin(buffer), end);
+
+    end = v1::aliveMessage(state2.nodeId, 3, toPayload(state2), begin(buffer));
+    messenger.receive(std::ref(handler));
+    wideIface.incomingMessage(
+      UdpEndpoint{makeAddress("123.123.255.254"), 1900}, begin(buffer), end);
+
+    REQUIRE(2 == handler.peerStates.size());
+    CHECK(state1.nodeId == handler.peerStates[0].peerState.nodeId);
+    CHECK(state2.nodeId == handler.peerStates[1].peerState.nodeId);
   }
 }
 

--- a/src/ableton/link/tst_Controller.cpp
+++ b/src/ableton/link/tst_Controller.cpp
@@ -100,7 +100,7 @@ struct MockIoContext
     return {};
   }
 
-  std::vector<discovery::IpAddress> scanNetworkInterfaces() { return {}; }
+  std::vector<discovery::InterfaceAddress> scanNetworkInterfaces() { return {}; }
 
   using Timer = util::test::Timer;
 

--- a/src/ableton/link_audio/tst_UdpMessenger.cpp
+++ b/src/ableton/link_audio/tst_UdpMessenger.cpp
@@ -155,8 +155,7 @@ TEST_CASE("UdpMessenger")
     discovery::UdpEndpoint{discovery::makeAddress("123.123.234.234"), 1900};
 
   ::ableton::test::serial_io::Fixture io;
-  auto pIface = std::make_shared<discovery::test::Interface>(
-    discovery::UdpEndpoint{discovery::makeAddress("123.123.234.42"), 1234});
+  auto pIface = std::make_shared<discovery::test::Interface>("123.123.234.42/24", 1234);
   TestObserver observer;
   TestHandler handler;
 


### PR DESCRIPTION
When trying to use Link on a /16 network (because of [APIPA](https://en.wikipedia.org/wiki/APIPA),) I had trouble getting sessions to see each other. After more debugging than I care to admit to, I discovered that [UdpMessenger.hpp:293](https://github.com/Ableton/link/blob/addb7dae39532420a304f5171d7ace9d3e8b1978/include/ableton/discovery/UdpMessenger.hpp#L293) uses a hardcoded prefix length of 24. This means that even though all my hosts had perfectly fine local IP addresses for a /16, Link dropped their messages because they didn't have the same third octet.

I made a version that does lookups of prefix length upon the creation of `IpInterface`, but then I realized that if someone were to set an IP, realize it's the wrong prefix length, and then change the prefix length, Link's interface scanner would possibly not pickup the change. So I made this version of the fix instead. It's _slightly_ extra work on each interface scan and for `repairGateway`, however I hope the reduced work for each packet makes up for it. (I think both sides are negligible enough that it doesn't really matter.)