### PR TITLE
Fix things for ESP-IDF 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           submodules: recursive
       - name: Build ESP-IDF
-        run: docker run --rm -v ${{ github.workspace }}:/link -w /link/examples/esp32 -e LC_ALL=C.UTF-8 espressif/idf:v5.1.1 idf.py build
+        run: docker run --rm -v ${{ github.workspace }}:/link -w /link/examples/esp32 -e LC_ALL=C.UTF-8 espressif/idf:v5.5 idf.py build
 
   check-formatting:
     runs-on: ubuntu-latest

--- a/include/ableton/link/PeerState.hpp
+++ b/include/ableton/link/PeerState.hpp
@@ -99,7 +99,7 @@ struct PeerState
   static PeerState fromPayload(NodeId id, It begin, It end)
   {
     using namespace std;
-    auto peerState = PeerState{NodeState::fromPayload(std::move(id), begin, end), {}};
+    auto peerState = PeerState{NodeState::fromPayload(std::move(id), begin, end), {}, {}};
 
     discovery::parsePayload<MeasurementEndpointV4,
                             MeasurementEndpointV6,

--- a/include/ableton/link/Peers.hpp
+++ b/include/ableton/link/Peers.hpp
@@ -151,21 +151,21 @@ public:
       auto pImpl = observer.mpImpl;
       auto addr = observer.mAddr;
       assert(pImpl);
-      pImpl->sawPeerOnGateway(std::move(state), std::move(addr));
+      pImpl->sawPeerOnGateway(state, std::move(addr));
     }
 
     friend void peerLeft(GatewayObserver& observer, const NodeId& id)
     {
       auto pImpl = observer.mpImpl;
       auto addr = observer.mAddr;
-      pImpl->peerLeftGateway(std::move(id), std::move(addr));
+      pImpl->peerLeftGateway(id, std::move(addr));
     }
 
     friend void peerTimedOut(GatewayObserver& observer, const NodeId& id)
     {
       auto pImpl = observer.mpImpl;
       auto addr = observer.mAddr;
-      pImpl->peerLeftGateway(std::move(id), std::move(addr));
+      pImpl->peerLeftGateway(id, std::move(addr));
     }
 
     std::shared_ptr<Impl> mpImpl;

--- a/include/ableton/platforms/esp32/ScanIpIfAddrs.hpp
+++ b/include/ableton/platforms/esp32/ScanIpIfAddrs.hpp
@@ -19,9 +19,16 @@
 
 #include <ableton/discovery/AsioTypes.hpp>
 #include <arpa/inet.h>
+#include <esp_idf_version.h>
 #include <esp_netif.h>
 #include <net/if.h>
 #include <vector>
+
+// esp_netif_next_unsafe() was introduced in ESP-IDF v5.5 as a rename of
+// esp_netif_next() to make the thread-unsafety explicit.
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 0)
+#define esp_netif_next_unsafe esp_netif_next
+#endif
 
 namespace ableton
 {
@@ -30,26 +37,36 @@ namespace platforms
 namespace esp32
 {
 
-// ESP32 implementation of ip interface address scanner
+// ESP32 implementation of ip interface address scanner.
+// Uses esp_netif_tcpip_exec() to iterate network interfaces safely from
+// the TCPIP thread, where the interface list is guaranteed stable.
+// esp_netif_tcpip_exec() is available in ESP-IDF v5.3 and later.
 struct ScanIpIfAddrs
 {
   std::vector<discovery::IpAddress> operator()()
   {
     std::vector<discovery::IpAddress> addrs;
-    // Get first network interface
-    esp_netif_t* esp_netif = esp_netif_next(NULL);
-    while (esp_netif)
-    {
-      // Check if interface is active
-      if (esp_netif_is_netif_up(esp_netif))
+    esp_netif_tcpip_exec(
+      [](void* ctx) -> esp_err_t
       {
-        esp_netif_ip_info_t ip_info;
-        esp_netif_get_ip_info(esp_netif, &ip_info);
-        addrs.emplace_back(::asio::ip::address_v4(ntohl(ip_info.ip.addr)));
-      }
-      // Get next network interface
-      esp_netif = esp_netif_next(esp_netif);
-    }
+        auto& out = *static_cast<std::vector<discovery::IpAddress>*>(ctx);
+        // Get first network interface
+        esp_netif_t* esp_netif = esp_netif_next_unsafe(NULL);
+        while (esp_netif)
+        {
+          // Check if interface is active
+          if (esp_netif_is_netif_up(esp_netif))
+          {
+            esp_netif_ip_info_t ip_info;
+            esp_netif_get_ip_info(esp_netif, &ip_info);
+            out.emplace_back(::asio::ip::address_v4(ntohl(ip_info.ip.addr)));
+          }
+          // Get next network interface
+          esp_netif = esp_netif_next_unsafe(esp_netif);
+        }
+        return ESP_OK;
+      },
+      &addrs);
     return addrs;
   }
 };


### PR DESCRIPTION
ESP-IDF 6.0 has a higher warning level, and has phased out `esp_netif_next()`.

`esp_netif_next_unsafe()` is basically the same, but the rename is to alert people to its inherent unsafe nature. Using `esp_netif_tcpip_exec()` ensures the proper safety and avoids use after free situations.

The redundant move and missing field initializer were causing build failures.